### PR TITLE
Make Vite template installation more consistent

### DIFF
--- a/packages/vite-template-redux/README.md
+++ b/packages/vite-template-redux/README.md
@@ -3,7 +3,7 @@
 Uses [Vite](https://vitejs.dev/), [Vitest](https://vitest.dev/), and [React Testing Library](https://github.com/testing-library/react-testing-library) to create a modern [React](https://react.dev/) app compatible with [Create React App](https://create-react-app.dev/)
 
 ```sh
-npx degit reduxjs/redux-templates/packages/vite-template-redux
+npx degit reduxjs/redux-templates/packages/vite-template-redux my-app
 ```
 
 ## Goals


### PR DESCRIPTION
This is what you put in the docs. Without the `my-app` you'd have to be in an empty directory.