### PR TITLE
[vite-template-redux] fix "ESLint couldn't find the plugin "eslint-pulgin-prettier"."

### DIFF
--- a/packages/vite-template-redux/package.json
+++ b/packages/vite-template-redux/package.json
@@ -29,6 +29,7 @@
     "@vitejs/plugin-react": "^4.0.0",
     "eslint": "^8.0.0",
     "eslint-config-react-app": "^7.0.1",
+    "eslint-plugin-prettier": "^4.2.1",
     "jsdom": "^21.1.0",
     "prettier": "^2.7.1",
     "prettier-config-nick": "^1.0.2",


### PR DESCRIPTION
Fix bellow error.

## Repoduction
1. `npx degit reduxjs/redux-templates/packages/vite-template-redux my-app`
2. `cd myapp`
3. `pnpm i`
4. `pnpm lint`
5. you'll see the error screenshot.

<img width="1720" alt="Screenshot 2023-05-04 at 3 05 40" src="https://user-images.githubusercontent.com/5501268/236007551-a0af06fc-faf0-4f68-a11d-93446f5ba1bc.png">
