### PR TITLE
vite-template-redux: Skip linting vite.config.ts, as it's not covered by tsconfig.json

### DIFF
--- a/packages/vite-template-redux/.eslintrc.json
+++ b/packages/vite-template-redux/.eslintrc.json
@@ -9,7 +9,7 @@
   "parserOptions": { "project": true, "tsconfigRootDir": "./" },
   "plugins": ["@typescript-eslint"],
   "root": true,
-  "ignorePatterns": ["dist"],
+  "ignorePatterns": ["dist", "vite.config.ts"],
   "rules": {
     "@typescript-eslint/consistent-type-imports": [
       2,


### PR DESCRIPTION
Fixes #132.